### PR TITLE
delay before moving files to external drive

### DIFF
--- a/field-node/files/move_old_subdirs_post_upload.sh.j2
+++ b/field-node/files/move_old_subdirs_post_upload.sh.j2
@@ -16,6 +16,10 @@ DEST_DIR="{{ seqdata_archival_path }}"
 
 if [ -d "$DEST_DIR" ]; then
   if $(mount | grep "$DEST_DIR" &> /dev/null); then
+  
+    # The MiSeq expects the run directory to be present during the post-run wash stage, even if sequencing has finished.
+    # The wash takes ~20 minutes, so we'll wait for 30 minutes to give it a chance to finish before copying files.
+    sleep 1800
     # rsync key:
     # -r = recursive
     # -l = copy links


### PR DESCRIPTION
The MiSeq expects the run directory to be present during the post-run wash stage, even if sequencing has finished. This can lead to an error if the upload to DNAnexus is fast and the post-upload script moves files before the wash has finished. The wash takes ~20 minutes, so we'll wait for 30 minutes to give it a chance to finish washing before copying files
