### PR TITLE
extend ansible timeout

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,8 @@
 [defaults]
 roles_path = ./roles/
 host_key_checking = False
+timeout = 80
 
 [ssh_connection]
 control_path = /tmp/%%h-%%p-%%r
-ssh_args = -o ControlMaster=auto -o ControlPersist=120s
+ssh_args = -o ControlMaster=auto -o ControlPersist=360s


### PR DESCRIPTION
add longer ansible timeout (80s vs default of 12s) for slow connections