### PR TITLE
append the relay domain if only the node name is given

### DIFF
--- a/connect.sh
+++ b/connect.sh
@@ -10,9 +10,10 @@ fi
 SCRIPT_DIRECTORY=$(dirname $0)
 
 NODE_DOMAIN=$1
-#RELAY_DOMAIN=""
+#RELAY_SUBDOMAIN=""
 
-RELAY_DOMAIN=$(cat $SCRIPT_DIRECTORY/settings_field_node.yml | grep "manager_domain_name" | perl -lape 's/(.*):\s*(\S*)/$2/g')
+RELAY_SUBDOMAIN=$(cat $SCRIPT_DIRECTORY/settings_field_node.yml | grep "manager_domain_name" | perl -lape 's/(.*):\s*(\S*)/$2/g')
+RELAY_DOMAIN=$(cat $SCRIPT_DIRECTORY/settings_field_node.yml | grep "^domain_name" | perl -lape 's/(.*):\s*(\S*)/$2/g')
 
 CONNECT_USERNAME=""
 if [[ ! -z "$2" && "$2" != " " ]]; then
@@ -21,9 +22,14 @@ else
     CONNECT_USERNAME="$(whoami)"
 fi
 
+# append the relay domain if only the node name is given
+if [[ -z "$(echo $1 | grep $RELAY_DOMAIN)" ]]; then
+    NODE_DOMAIN="$NODE_DOMAIN.$RELAY_DOMAIN"
+fi
+
 # get the IP of the manager node
 # use the AWS nameserver to ensure most current DNS records
-MANAGER_IP=$(dig A +short $RELAY_DOMAIN @ns-491.awsdns-61.com)
+MANAGER_IP=$(dig A +short $RELAY_SUBDOMAIN @ns-491.awsdns-61.com)
 
 # get the port from the DNS TXT record for this subdomain
 # use the AWS nameserver to ensure most current DNS records
@@ -34,10 +40,10 @@ if [[ -z "$PORT_ON_RELAY" || "$PORT_ON_RELAY" == " " ]]; then
         exit 1
 fi
 
-echo "Connecting to '$NODE_DOMAIN' via local port '$PORT_ON_RELAY' on relay '$RELAY_DOMAIN'"
+echo "Connecting to '$NODE_DOMAIN' via local port '$PORT_ON_RELAY' on relay '$RELAY_SUBDOMAIN'"
 echo ""
-echo "Note: a live reverse tunnel must be present between '$NODE_DOMAIN' and '$RELAY_DOMAIN'"
-echo "      binding the SSH port of '$NODE_DOMAIN' to the local port '$PORT_ON_RELAY' on '$RELAY_DOMAIN.'"
+echo "Note: a live reverse tunnel must be present between '$NODE_DOMAIN' and '$RELAY_SUBDOMAIN'"
+echo "      binding the SSH port of '$NODE_DOMAIN' to the local port '$PORT_ON_RELAY' on '$RELAY_SUBDOMAIN.'"
 echo ""
 
 echo "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ProxyCommand=\"ssh -W %h:%p $CONNECT_USERNAME@$MANAGER_IP\" $CONNECT_USERNAME@localhost -p $PORT_ON_RELAY"


### PR DESCRIPTION
allows for shorthand `connect.sh nodename` rather than `connect.sh nodename.example.com`