### PR TITLE
travis-ci.ORG -> travis-ci.COM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/broadinstitute/sabetilab-remote-config.svg?token=MpDq9eJxuo1jZsXqvFHq&branch=master)](https://travis-ci.org/broadinstitute/sabetilab-remote-config)
+[![Build Status](https://travis-ci.com/broadinstitute/sabetilab-remote-config.svg?token=MpDq9eJxuo1jZsXqvFHq&branch=master)](https://travis-ci.com/broadinstitute/sabetilab-remote-config)
 
 # sabetilab-remote-config
 remote configuration files for systems at African field sites


### PR DESCRIPTION
Update the badge to reflect a transition from the .org version of TravisCI to the .com version, in support of a migration from the deprecated GitHub service integration to the new "app."