### PR TITLE
route53 api lib change

### DIFF
--- a/field-node/files/requirements.txt
+++ b/field-node/files/requirements.txt
@@ -1,4 +1,3 @@
-Area53==0.94
 boto==2.48.0
 dnspython==1.12.0
 requests==2.20.0

--- a/field-node/files/requirements.txt
+++ b/field-node/files/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.48.0
 dnspython==1.12.0
 requests==2.20.0
-urllib3
+urllib3==1.25.6
 psutil
 ipaddress

--- a/field-node/files/update_route53.py.j2
+++ b/field-node/files/update_route53.py.j2
@@ -12,7 +12,8 @@ from datetime import datetime
 os.environ["AWS_ACCESS_KEY_ID"] = "{{aws_access_key_id}}"
 os.environ["AWS_SECRET_ACCESS_KEY"] = "{{aws_secret_access_key}}"
 
-from area53 import route53
+import boto.route53
+from boto.route53.record import ResourceRecordSets
 from boto.route53.exception import DNSServerError
 import requests
 import ipaddress
@@ -56,9 +57,27 @@ def get_txt_rec(domain_name):
     resolver.nameservers=[ socket.gethostbyname('ns-491.awsdns-61.com') ]
     return str(resolver.query(domain_name, 'TXT')[0]).replace('"','')
 
-def get_port(domain_name):
+def get_a_rec(domain_name):
+    resolver = dns.resolver.Resolver()
+    resolver.nameservers=[ socket.gethostbyname('ns-491.awsdns-61.com') ]
+    return str(resolver.query(domain_name, 'A')[0]).replace('"','')
+
+def get_aaaa_rec(domain_name):
+    resolver = dns.resolver.Resolver()
+    resolver.nameservers=[ socket.gethostbyname('ns-491.awsdns-61.com') ]
+    return str(resolver.query(domain_name, 'AAAA')[0]).replace('"','')
+
+def get_port_from_public_txt(domain_name):
     txt_record = get_txt_rec(domain_name)
-    port_num_matches = re.findall(r'^P(\d+);.*', txt_record)
+    port_num_matches = re.findall(r'^"?P(\d+);.*', txt_record)
+    port_num = ""
+    if len(port_num_matches) > 0:
+        port_num = port_num_matches[0]
+
+    return port_num
+
+def parse_port(txt_str):
+    port_num_matches = re.findall(r'^"?P(\d+);.*', txt_str)
     port_num = ""
     if len(port_num_matches) > 0:
         port_num = port_num_matches[0]
@@ -66,24 +85,23 @@ def get_port(domain_name):
     return port_num
 
 def update_dns(subdomain, domain, new_ip, new_port):
-    fqdn = '%s.%s' % (subdomain, domain)
-    zone = route53.get_zone(domain)
-    a_record = zone.get_a(fqdn)
-    aaaa_record = zone.get_aaaa(fqdn)
+    fqdn = '%s.%s.' % (subdomain, domain)
+    conn = boto.route53.connect_to_region("eu-west-1")
+    zone = conn.get_zone(domain)
+    change_set = ResourceRecordSets(conn, zone.id)
 
     datestr = '"P%s; Last update %s."' % (new_port, datetime.utcnow().strftime('%Y-%m-%d %H:%M'))
 
     if type(ipaddress.ip_address(new_ip)) == ipaddress.IPv4Address:
-        update_rec_name = zone.update_a
-        add_rec_name    = zone.add_a
-        record          = a_record
+        record_ip_type = "A"
     elif type(ipaddress.ip_address(new_ip)) == ipaddress.IPv6Address:
-        update_rec_name = zone.update_aaaa
-        add_rec_name    = zone.add_aaaa
-        record          = aaaa_record
+        record_ip_type = "AAAA"
+
+    record = conn.get_all_rrsets(zone.id, type=record_ip_type, name=fqdn, maxitems=1)[0]
+    record_txt = conn.get_all_rrsets(zone.id, type="TXT", name=fqdn, maxitems=1)[0]
 
     if record:
-        old_port = get_port(fqdn)
+        old_port = parse_port(record_txt.resource_records[0]) #get_port_from_public_txt(fqdn)
         old_ip = record.resource_records[0]
 
         if old_ip == new_ip and old_port == new_port:
@@ -92,25 +110,23 @@ def update_dns(subdomain, domain, new_ip, new_port):
                 sys.exit(0)
 
         if old_ip != new_ip:
-            try:
-                if sys.stdin.isatty():
-                    print('Updating %s: %s -> %s' % (fqdn, old_ip, new_ip))
-                update_rec_name(fqdn, new_ip, 900)
-            except DNSServerError:
-                # create the record
-                add_rec_name(fqdn, new_ip, 900)
+            if sys.stdin.isatty():
+                print('Updating %s: %s -> %s' % (fqdn, old_ip, new_ip))
+            changes1 = change_set.add_change("UPSERT", fqdn, type=record_ip_type, ttl=900)
+            changes1.add_value(new_ip)
 
         if old_port != new_port:
-            try:
-                if sys.stdin.isatty():
-                    print('Updating port for %s: %s -> %s' % (fqdn, old_port, new_port))
-                zone.update_txt(fqdn, datestr, 900)
-            except DNSServerError:
-                # create the record
-                zone.add_txt(fqdn, datestr, 900)
+            if sys.stdin.isatty():
+                print('Updating port for %s: %s -> %s' % (fqdn, old_port, new_port))
+            changes1 = change_set.add_change("UPSERT", fqdn, type="TXT", ttl=600)
+            changes1.add_value(datestr)
     else:
-            add_rec_name(fqdn, new_ip, 900)
-            zone.add_txt(fqdn, datestr, 900)
+        changes1 = change_set.add_change("UPSERT", fqdn, type="TXT", ttl=600)
+        changes1.add_value(datestr)
+        changes1 = change_set.add_change("UPSERT", fqdn, type=record_ip_type, ttl=900)
+        changes1.add_value(new_ip)
+
+    change_set.commit()
 
 if __name__ == "__main__":
     try:

--- a/field-node/node-base.yml
+++ b/field-node/node-base.yml
@@ -8,6 +8,8 @@
 
   vars:
     security_ssh_port: "{{ ssh_port }}"
+    system76_machines_to_install_drivers:
+      - "Gazelle" # System76 model of laptop
 
   roles:
     - geerlingguy.security # this will disconnect SSH, and must be run locally
@@ -95,6 +97,22 @@
       pip: 
         requirements: "/opt/field-node/python-requirements.txt"
         #extra_args: --ignore-installed
+
+    - name: get machine model number
+      shell: "dmidecode -s system-product-name"
+      register: model_number
+
+    - debug: 
+        msg: "Machine identified as {{model_number.stdout}}"
+
+    - name: install System76 package source if they make this computer model
+      apt_repository:
+        repo: ppa:system76-dev/stable
+      when: (model_number.stdout in system76_machines_to_install_drivers)
+
+    - name: install System76 driver if they make this computer model
+      apt: pkg=system76-driver state=present
+      when: (model_number.stdout in system76_machines_to_install_drivers)
 
     # - name: Ensure .ssh directory exists.
     #   file: 

--- a/field-node/node-power-policy.yml
+++ b/field-node/node-power-policy.yml
@@ -15,6 +15,7 @@
       - "Precision M4800"
       - "Precision 7510" # REQUIRES BIOS >1.4.8 
       - "Precision 7710"
+      - "Gazelle" # System76 model of laptop
 
   tasks:
     - name: get machine swap partition size (kB)

--- a/roles/debops.ferm/tasks/main.yml
+++ b/roles/debops.ferm/tasks/main.yml
@@ -18,10 +18,9 @@
 
 - name: Ensure ferm is installed
   apt:
-    name: '{{ item }}'
+    name: '{{ ferm_packages }}'
     state: 'present'
     install_recommends: 'no'
-  with_items: "{{ ferm_packages }}"
   when: (ferm_enabled | bool and (ansible_local|d() and
          (ansible_local.root|d() and (ansible_local.root.flags | intersect(ferm_root_flags.cap_net_admin)) or
          (ansible_local.cap12s|d() and (not ansible_local.cap12s.enabled | bool or

--- a/roles/debops.samba/tasks/main.yml
+++ b/roles/debops.samba/tasks/main.yml
@@ -1,8 +1,15 @@
 ---
 
 - name: Install Samba packages
-  apt: pkg={{ item }} state=latest install_recommends=no
-  with_items: [ 'samba', 'samba-common', 'samba-common-bin' ]
+  apt:
+    state: latest
+    install_recommends: no
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - 'samba'
+      - 'samba-common'
+      - 'samba-common-bin'
 
 - name: Create root Samba directories
   file: path={{ item }} state=directory owner=root group=root mode=0751

--- a/roles/dx-streaming-upload/tasks/main.yml
+++ b/roles/dx-streaming-upload/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Get DX tarball
   get_url:
     #url: https://wiki.dnanexus.com/images/files/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
-    url: https://wiki.dnanexus.com/images/files/dx-toolkit-v0.263.0-ubuntu-16.04-amd64.tar.gz
+    url: https://dnanexus-sdk.s3.amazonaws.com/dx-toolkit-v0.286.1-ubuntu-16.04-amd64.tar.gz
     dest: /opt/dx-toolkit-current-ubuntu-16.04-amd64.tar.gz
     mode: 0740
     timeout: 600
@@ -33,7 +33,7 @@
 
 - name: Get UA tarball
   get_url:
-    url: https://wiki.dnanexus.com/images/files/dnanexus-upload-agent-current-linux.tar.gz
+    url: https://dnanexus-sdk.s3.amazonaws.com/dnanexus-upload-agent-1.5.31-linux.tar.gz
     dest: /opt/dnanexus-upload-agent-current-linux.tar.gz
     mode: 0740
     timeout: 600


### PR DESCRIPTION
- functions from Area53/slick53 have been merged to boto core, so not we can remove the (deprecated) external dependency and use native boto to interface with route53
- install system76 drivers where appropriate
- shift to newer ansible syntax in a few places
- updates `dx-toolkit`